### PR TITLE
Avoid per-frame GC allocations + Compatibility with Single Pass Instanced rendering

### DIFF
--- a/Runtime/RendererFeatures/CustomToneMapChain.shader
+++ b/Runtime/RendererFeatures/CustomToneMapChain.shader
@@ -66,7 +66,7 @@ Shader "Hidden/CustomToneMapChain"
             #pragma fragment Frag
 
             #if !defined(LEGACY_RENDER_PATH)
-            FRAMEBUFFER_INPUT_X_HALF(0);
+            FRAMEBUFFER_INPUT_HALF(0);
             #endif
 
             float3 ToneMap(float3 color)
@@ -94,7 +94,7 @@ Shader "Hidden/CustomToneMapChain"
                 color = LOAD_TEXTURE2D(_MainTex, input.positionCS.xy).rgb;
                 #else
                 // RenderGraph path: Use framebuffer fetch
-                color = LOAD_FRAMEBUFFER_X_INPUT(0, input.positionCS.xy).rgb;
+                color = LOAD_FRAMEBUFFER_INPUT(0, input.positionCS.xy).rgb;
                 #endif
 
                 return float4(ToneMap(color), 1.0);

--- a/Runtime/RendererFeatures/CustomToneMappingPass.cs
+++ b/Runtime/RendererFeatures/CustomToneMappingPass.cs
@@ -61,7 +61,7 @@ namespace CustomToneMapping.URP.RendererFeatures
             if (!resourceData.internalColorLut.IsValid()) return;
 
             // Prevent double tonemapping
-            if (VolumeManager.instance.stack.GetComponent<Tonemapping>().mode != TonemappingMode.None)
+            if (VolumeManager.instance.stack.GetComponent<Tonemapping>().mode.value != TonemappingMode.None)
             {
                 return;
             }

--- a/Runtime/URP/UrpBridge.cs
+++ b/Runtime/URP/UrpBridge.cs
@@ -39,7 +39,7 @@ namespace CustomToneMapping.URP
             );
         }
 
-        private static bool TryGetOrBakeLut(ILutConfig config, out Texture2D tex, out Vector3 lutParamsSample)
+        private static bool TryGetOrBakeLut<T>(T config, out Texture2D tex, out Vector3 lutParamsSample) where T : ILutConfig
         {
             tex = null;
             lutParamsSample = GetLutParams(config.LutSize);


### PR DESCRIPTION
Some small changes based on my own needs. Per-frame GC allocation has been avoided and the shader tweak should allow tonemapping to work with Single Pass Instanced rendering. Please give the changes a look when you can. 

This is a fantastic project. Keep up the good work!